### PR TITLE
add runtime refresh for sideloaded-plugins

### DIFF
--- a/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/PluginManager.java
@@ -314,7 +314,6 @@ public class PluginManager
 						try {
 							SwingUtilities.invokeAndWait(() -> {
 								try {
-									//newPluginLoaded.resetConfiguration();
 									eventBus.register(newPluginLoaded);
 									startPlugin(newPluginLoaded);
 									loadedPluginNames.add(f.getName());

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPanel.java
@@ -40,7 +40,9 @@ import net.runelite.api.Client;
 import net.runelite.api.GameState;
 import net.runelite.api.MenuAction;
 import net.runelite.client.Notifier;
+import net.runelite.client.account.SessionManager;
 import net.runelite.client.callback.ClientThread;
+import net.runelite.client.plugins.PluginManager;
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.PluginPanel;
 import net.runelite.client.ui.overlay.OverlayMenuEntry;
@@ -62,19 +64,21 @@ class DevToolsPanel extends PluginPanel
 	private final InventoryInspector inventoryInspector;
 	private final InfoBoxManager infoBoxManager;
 	private final ScheduledExecutorService scheduledExecutorService;
+	private final PluginManager pluginManager;
 
 	@Inject
 	private DevToolsPanel(
-		Client client,
-		ClientThread clientThread,
-		DevToolsPlugin plugin,
-		WidgetInspector widgetInspector,
-		VarInspector varInspector,
-		ScriptInspector scriptInspector,
-		InventoryInspector inventoryInspector,
-		Notifier notifier,
-		InfoBoxManager infoBoxManager,
-		ScheduledExecutorService scheduledExecutorService)
+			Client client,
+			ClientThread clientThread,
+			DevToolsPlugin plugin,
+			WidgetInspector widgetInspector,
+			VarInspector varInspector,
+			ScriptInspector scriptInspector,
+			InventoryInspector inventoryInspector,
+			Notifier notifier,
+			InfoBoxManager infoBoxManager,
+			ScheduledExecutorService scheduledExecutorService,
+			PluginManager pluginManager)
 	{
 		super();
 		this.client = client;
@@ -87,6 +91,7 @@ class DevToolsPanel extends PluginPanel
 		this.notifier = notifier;
 		this.infoBoxManager = infoBoxManager;
 		this.scheduledExecutorService = scheduledExecutorService;
+		this.pluginManager = pluginManager;
 
 		setBackground(ColorScheme.DARK_GRAY_COLOR);
 
@@ -181,6 +186,11 @@ class DevToolsPanel extends PluginPanel
 		container.add(disconnectBtn);
 
 		container.add(plugin.getRoofs());
+
+		final JButton sidePluginsBtn = new JButton("Refresh Side Plugins");
+		sidePluginsBtn.addActionListener(e ->
+			clientThread.invoke(pluginManager::loadSideLoadPlugins));
+		container.add(sidePluginsBtn);
 
 		try
 		{

--- a/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
+++ b/runelite-client/src/main/java/net/runelite/client/plugins/devtools/DevToolsPlugin.java
@@ -167,6 +167,7 @@ public class DevToolsPlugin extends Plugin
 	private DevToolsButton shell;
 	private DevToolsButton menus;
 	private DevToolsButton uiDefaultsInspector;
+	private DevToolsButton refreshSidePlugins;
 	private NavigationButton navButton;
 
 	private HotkeyListener swingInspectorHotkeyListener = new HotkeyListener(() -> config.swingInspectorHotkey())
@@ -267,6 +268,7 @@ public class DevToolsPlugin extends Plugin
 		roofs = new DevToolsButton("Roofs");
 		shell = new DevToolsButton("Shell");
 		menus = new DevToolsButton("Menus");
+		refreshSidePlugins = new DevToolsButton("Refresh Side Plugins");
 
 		uiDefaultsInspector = new DevToolsButton("Swing Defaults");
 


### PR DESCRIPTION
**Description:**
As we discussed before I have only implemented a way to add new sideloaded-plugins, since this is what we really wanted.
If we remove an old plugin in runtime and click in Refresh Side Load button this will not remove the plugin. In order to do that you have to rebuild the app to properly have that in place. If you add new plugins please keep in mind that the pluginDescriptor name need to be different to properly see the desired new plugin.

**Test:**
In order to test it I have used the new runeliters repo to create new plugins and add them to sideloaded-plugins/folder automatically.